### PR TITLE
Missing some cookbook depenencies

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,7 @@
 
 case node[:platform]
 when "debian", "ubuntu"
+  require_recipe "git"
   git "/usr/share/drush" do
     repository "git://git.drupalcode.org/project/drush.git"
     reference "7.x-4.4"
@@ -30,11 +31,10 @@ when "debian", "ubuntu"
     not_if { File.exists?("/usr/bin/drush") }
     only_if { File.exists?("/usr/share/drush/drush") }
   end
-
-  bash "install-console-table" do
-    code <<-EOH
-    (pear install Console_Table)
-    EOH
-    not_if "pear list| grep Console_Table"
+  
+  include_recipe "php"
+  php_pear "Console_Table" do
+    action :install
   end
+
 end


### PR DESCRIPTION
Added proper dependencies on php cookbook (for php_pear LWRP) and git cookbook (for fetching drush).

Hey Mark, looks like you were maybe working on a system that already had them installed and didn't notice, but on a virgin system, the default git and php recipes should probably be installed. You were doing a manual pear install, but there's a resource for it:
http://wiki.opscode.com/display/chef/Opscode+LWRP+Resources#OpscodeLWRPResources-phppear

Let me know if anything looks off :)
