### PR TITLE
Install drush via PEAR channel

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,0 +1,44 @@
+= DESCRIPTION:
+
+Installs drush via PEAR packages. Also included is a recipe that can be used 
+to install drush_make via the `drush pm-download` command.
+
+= REQUIREMENTS:
+
+* Opscode's php cookbook - http://community.opscode.com/cookbooks/php/
+
+= PLATFORMS:
+
+The following platforms are supported by this cookbook, meaning that the 
+recipes run on these platforms without error.
+
+* Debian
+* Ubuntu
+* CentOS
+
+= RECIPES:
+
+== default:
+
+Includes the default recipe in a run list
+
+== make:
+
+Executes a drush command to install drush_make.  If any version of 
+drush_make was previously installed, this command will not be run.
+
+= ATTRIBUTES:
+
+== default:
+
+* node[:drush][:version] - version from http://pear.drush.org/
+
+== make:
+
+* node[:drush][:make][:version] - version from http://www.drupal.org/project/drush_make/
+* node[:drush][:make][:install_dir] - where the command should be installed
+
+= USAGE:
+
+Simply include the `drush` or `drush::make` recipe where ever you would 
+like drush installed.

--- a/README.rdoc
+++ b/README.rdoc
@@ -40,5 +40,5 @@ drush_make was previously installed, this command will not be run.
 
 = USAGE:
 
-Simply include the `drush` or `drush::make` recipe where ever you would 
+Simply include the `drush` or `drush::make` recipe wherever you would
 like drush installed.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 # 
 # Cookbook Name:: drush
-# Recipe:: default
+# Attributes:: drush
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,23 +15,4 @@
 # limitations under the License.
 #
 
-include_recipe "php"
-
-# Upgrade PEAR to latest stable version
-# For example, 1.9.4 works for drush, but 1.9.0 does not
-php_pear 'pear' do
-  preferred_state "stable"
-  action :upgrade
-end
-
-# Initialize drush PEAR channel
-dc = php_pear_channel "pear.drush.org" do
-  action :discover
-end
-
-# Install drush
-php_pear "drush" do
-  version node[:drush][:version]
-  channel dc.channel_name
-  action :install
-end
+default[:drush][:version] = "4.5.0"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 # 
+# Author:: David King <dking@xforty.com>
 # Cookbook Name:: drush
-# Attributes:: drush
+# Attributes:: default
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,5 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# Pear search does not currently work with the preferred state. So we have to
+# specify a default version for now.  https://pear.php.net/bugs/bug.php?id=19138
+# TODO: implement preferred_state attribute and logic once pear bug is fixed
 
 default[:drush][:version] = "4.5.0"

--- a/attributes/make.rb
+++ b/attributes/make.rb
@@ -1,6 +1,6 @@
 # 
 # Cookbook Name:: drush
-# Recipe:: default
+# Attributes:: make
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,23 +15,5 @@
 # limitations under the License.
 #
 
-include_recipe "php"
-
-# Upgrade PEAR to latest stable version
-# For example, 1.9.4 works for drush, but 1.9.0 does not
-php_pear 'pear' do
-  preferred_state "stable"
-  action :upgrade
-end
-
-# Initialize drush PEAR channel
-dc = php_pear_channel "pear.drush.org" do
-  action :discover
-end
-
-# Install drush
-php_pear "drush" do
-  version node[:drush][:version]
-  channel dc.channel_name
-  action :install
-end
+default[:drush][:make][:version] = "6.x-2.3"
+default[:drush][:make][:install_dir] = "/usr/share/php/drush/commands"

--- a/attributes/make.rb
+++ b/attributes/make.rb
@@ -1,4 +1,5 @@
 # 
+# Author:: David King <dking@xforty.com>
 # Cookbook Name:: drush
 # Attributes:: make
 #
@@ -15,5 +16,5 @@
 # limitations under the License.
 #
 
-default[:drush][:make][:version] = "6.x-2.3"
+default[:drush][:make][:version]     = "6.x-2.3"
 default[:drush][:make][:install_dir] = "/usr/share/php/drush/commands"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,9 +6,9 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.9.2"
 depends          "php"
 
-recipe           "drush", "Installs drush"
-recipe           "drush::make", "Installs drush_make, first making sure drush is installed"
-recipe           "drush::dev", "Installs master branch of drush from git"
+recipe           "drush",             "Installs drush"
+recipe           "drush::make",       "Installs drush_make, first making sure drush is installed"
+recipe           "drush::dev",        "Installs master branch of drush from git"
 recipe           "drush::drush4-dev", "Installs 7.x-4.x branch of drush from git"
 
 %w{ debian ubuntu centos }.each do |os|

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,11 +2,16 @@ maintainer       "Mark Sonnabaum"
 maintainer_email "mark.sonnabaum@acquia.com"
 license          "Apache 2.0"
 description      "Installs drush"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.9.2"
 depends          "php"
-recipe "drush", "Installs drush"
 
-%w{ debian ubuntu arch centos }.each do |os|
+recipe           "drush", "Installs drush"
+recipe           "drush::make", "Installs drush_make, first making sure drush is installed"
+recipe           "drush::dev", "Installs master branch of drush from git"
+recipe           "drush::drush4-dev", "Installs 7.x-4.x branch of drush from git"
+
+%w{ debian ubuntu centos }.each do |os|
   supports os
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,3 +36,8 @@ php_pear "drush" do
   channel dc.channel_name
   action :install
 end
+
+# Install Console_Table
+php_pear "Console_Table" do
+  action :install
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,11 +17,11 @@
 
 include_recipe "php"
 
-# Upgrade PEAR to latest stable version
-# For example, 1.9.4 works for drush, but 1.9.0 does not
-php_pear 'pear' do
-  preferred_state "stable"
+# Upgrade PEAR if current version is < 1.9.1
+php_pear "pear" do
+  cur_version = `pear -V| head -1| awk -F': ' '{print $2}'`
   action :upgrade
+  not_if { Gem::Version.new(cur_version) > Gem::Version.new('1.9.0') }
 end
 
 # Initialize drush PEAR channel

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,5 @@
 # 
+# Author:: Mark Sonnabaum <mark.sonnabaum@acquia.com>
 # Cookbook Name:: drush
 # Recipe:: default
 #

--- a/recipes/dev.rb
+++ b/recipes/dev.rb
@@ -1,6 +1,6 @@
 # Author:: Mark Sonnabaum <mark.sonnabaum@acquia.com>
-# Cookbook Name::  drush
-# Recipe:: default
+# Cookbook Name:: drush
+# Recipe:: dev
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/drush4-dev.rb
+++ b/recipes/drush4-dev.rb
@@ -1,6 +1,6 @@
 # Author:: Mark Sonnabaum <mark.sonnabaum@acquia.com>
-# Cookbook Name::  drush
-# Recipe:: default
+# Cookbook Name:: drush
+# Recipe:: drush4-dev
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/make.rb
+++ b/recipes/make.rb
@@ -1,4 +1,5 @@
 # 
+# Author:: David King <dking@xforty.com>
 # Cookbook Name:: drush
 # Recipe:: make
 #

--- a/recipes/make.rb
+++ b/recipes/make.rb
@@ -1,6 +1,6 @@
 # 
 # Cookbook Name:: drush
-# Recipe:: default
+# Recipe:: make
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,23 +15,12 @@
 # limitations under the License.
 #
 
-include_recipe "php"
+# Make sure drush is installed first
+include_recipe "drush"
 
-# Upgrade PEAR to latest stable version
-# For example, 1.9.4 works for drush, but 1.9.0 does not
-php_pear 'pear' do
-  preferred_state "stable"
-  action :upgrade
-end
-
-# Initialize drush PEAR channel
-dc = php_pear_channel "pear.drush.org" do
-  action :discover
-end
-
-# Install drush
-php_pear "drush" do
-  version node[:drush][:version]
-  channel dc.channel_name
-  action :install
+# Install drush_make
+# TODO: come up with a way to allow users to update drush_make
+execute "install_drush_make" do
+  command "drush dl drush_make-#{node[:drush][:make][:version]} --destination=#{node[:drush][:make][:install_dir]}"
+  not_if "drush | grep make"
 end


### PR DESCRIPTION
- drush is installed via PEAR channel.
- added recipe to install drush_make.
- added a README file.
- added attributes files for recipe defaults.
- updated metadata to include all pieces of the cookbook.
