### PR TITLE
Use pear preferred states for drush version

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -49,8 +49,9 @@ is already available, this command will not be run.
 == default:
 
 * `node['drush']['install_method']` - Indicates the desired install method, currently either `git` or `pear`.
-* `node['drush']['version']` - Drush version of format x.y.z when install_method is pear (eg. 5.0.0).
+* `node['drush']['version']` - Drush preferred state (stable, beta, devel) or version of format x.y.z when install_method is pear (eg. 5.0.0).
 When install_method is git, the format is a git reference commit/tag/branch (eg. 31d768a / 7.x-4.x / 7.x-5.0 )
+* `node['drush']['allreleases']` - URL of allreleases.xml for pear to install from preferred states.
 * `node['drush']['make']['version']` - Drush Make version of format x.y
 * `node['drush']['install_dir']` - Where to install Drush via Git. Used to install Drush Make as well.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,17 +17,20 @@
 # limitations under the License.
 #
 
-# Pear search does not currently work with the preferred state. So we have to
-# specify a default version for now.  https://pear.php.net/bugs/bug.php?id=19138
-# TODO: implement preferred_state attribute and logic once pear bug is fixed
-
 # Options: pear, git
 default['drush']['install_method'] = "pear"
 
 # Used for drush install via git and make install (PEAR stores here by default).
 default['drush']['install_dir'] = "/usr/share/php/drush"
 
-# When installing via PEAR, this is the x.y.z pear version (eg. 4.5.0)
-# When installing via Git, this is a commit/tag/branch reference (eg. 6e4c1e22f0b / 7.x-4.5 / 7.x-4.x)
-default['drush']['version'] = "5.0.0"
+# When installing via PEAR, this is the preferred state (stable, beta, devel)
+# or a specific x.y.z pear version (eg. 4.5.0).  When installing via Git,
+# this is a commit/tag/branch reference (eg. 6e4c1e22f0b / 7.x-4.5 / 7.x-4.x)
+default['drush']['version'] = "stable"
+
+# URL of allreleases.xml for pear to install from preferred states
+default['drush']['allreleases'] = "http://pear.drush.org/rest/r/drush/allreleases.xml"
+
+# Version number (without drupal major version) from
+# http://drupal.org/project/drush_make
 default['drush']['make']['version'] = "2.3"

--- a/recipes/pear.rb
+++ b/recipes/pear.rb
@@ -19,6 +19,20 @@
 
 include_recipe "php"
 
+# If drush version is a preferred state, get the latest version of that state
+case node['drush']['version']
+when 'stable', 'beta', 'devel'
+  require 'rexml/document'
+  require 'open-uri'
+  xml = REXML::Document.new(open(node['drush']['allreleases']))
+  xml.root.each_element('r') do |release|
+    if release.text('s') == node['drush']['version']
+      node['drush']['version'] = release.text('v')
+      break
+    end
+  end
+end
+
 # Initialize drush PEAR channel
 dc = php_pear_channel "pear.drush.org" do
   action :discover


### PR DESCRIPTION
Instead of specifying a specific version number, you can now specify
a pear preferred state. For example, if you set the version to
"stable", the latest stable version will be installed. See
https://github.com/msonnabaum/chef-drush/issues/13 for more info.
