### PR TITLE
This broke on Chef 11

### DIFF
--- a/recipes/pear.rb
+++ b/recipes/pear.rb
@@ -27,7 +27,7 @@ when 'stable', 'beta', 'devel'
   xml = REXML::Document.new(open(node['drush']['allreleases']))
   xml.root.each_element('r') do |release|
     if release.text('s') == node['drush']['version']
-      node['drush']['version'] = release.text('v')
+      node.default['drush']['version'] = release.text('v')
       break
     end
   end


### PR DESCRIPTION
Chef 11 requires

```
node.default['drush']['version'] = release.text('v')
```

or it thinks attributes are read-only

There may be other instances of this in the cookbook, I don't know, but this fixes it just enough to make it work for us

:)
