### PR TITLE
Add redhat as supported platform

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ recipe           "drush::pear", "Installs Drush via PEAR."
 recipe           "drush::git",  "Installs Drush via Git (drupal.org repository)"
 recipe           "drush::make", "Installs Drush Make via Drush. NOT required for Drush 5."
 
-%w{ debian ubuntu centos }.each do |os|
+%w{ debian ubuntu centos redhat }.each do |os|
   supports os
 end
 

--- a/recipes/git.rb
+++ b/recipes/git.rb
@@ -19,13 +19,13 @@
 require_recipe "git"
 
 case node[:platform]
-when "debian", "ubuntu", "centos"
+when "debian", "ubuntu", "centos", "redhat"
   git node['drush']['install_dir'] do
     repository "git://git.drupalcode.org/project/drush.git"
     reference node['drush']['version']
     action :sync
   end
-  
+
   link "/usr/bin/drush" do
     to "#{node['drush']['install_dir']}/drush"
   end


### PR DESCRIPTION
Hi,

I noticed redhat platform is not supported in the git.rb recipe. I tested it on an instance with red hat enterprise linux and it works just fine. 

What about merging this change?

Best regards,
Kamil
