### PR TITLE
Add correct version dependency.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ license          "Apache 2.0"
 description      "Installs drush"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.10.0"
-depends          "php"
+depends          "php", "~> 1.1.0"
 recommends       "git"
 suggests         "subversion"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          "Apache 2.0"
 description      "Installs drush, the Drupal Shell."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.10.0"
-depends          "php", "~> 1.1.0"
+depends          "php", "~> 0.99.0"
 recommends       "git"
 
 recipe           "drush",       "Installs Drush and dependencies."


### PR DESCRIPTION
Support for pear was added in the php cookbook version 1.1.0.
