### PR TITLE
Remove subversion from suggested cookbook list.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,6 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.10.0"
 depends          "php"
 recommends       "git"
-suggests         "subversion"
 
 recipe           "drush",       "Installs Drush and dependencies."
 recipe           "drush::pear", "Installs Drush via PEAR."


### PR DESCRIPTION
Drush provides integration with Subversion; but also with Bazaar, curl or wget, rsync, gzip, open or xdg-open, etc, and presumably other programs in the future.

IMO, we should either include suggestions for the aforementioned programs or avoid referencing programs that work with Drush altogether.

If we avoid referencing programs that work with Drush, then we can avoid chasing Drush HEAD as often.
