### PR TITLE
Fix "cookbook drush not found" fatal error on provision

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,6 @@
 
 include_recipe "php"
 # Upgrade PEAR if current version is < 1.9.1
-include_recipe "drush::upgrade_pear" if node['drush']['install_method'] == "pear"
-include_recipe "drush::install_console_table"
-include_recipe "drush::#{node['drush']['install_method']}"
+include_recipe "chef-drush::upgrade_pear" if node['drush']['install_method'] == "pear"
+include_recipe "chef-drush::install_console_table"
+include_recipe "chef-drush::#{node['drush']['install_method']}"

--- a/recipes/make.rb
+++ b/recipes/make.rb
@@ -17,7 +17,7 @@
 #
 
 # Make sure drush is installed first
-include_recipe "drush"
+include_recipe "chef-drush"
 
 # Install drush_make
 # TODO: come up with a way to allow users to update drush_make


### PR DESCRIPTION
Either the name of the repository changed from `drush` to `chef-drush` at some point in the past, or everyone's been cloning to a folder named `drush`...

Either way, we should refer to the cookbook by it's correct machine name: `chef-drush` to avoid "cookbook drush not found" errors when using librarian-chef to manage cookbooks or when cloning this project without renaming the output folder.
