### PR TITLE
Composer installation option recipe.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = DESCRIPTION:
 
-Installs the Drush CLI tool for Drupal, either via PEAR package or directly from source via Git.
+Installs the Drush CLI tool for Drupal, either via PEAR package, Composer, or directly from source via Git.
 Also included is a recipe that can be used to install drush_make via the `drush pm-download` command.
 
 = REQUIREMENTS:
@@ -9,7 +9,7 @@ Also included is a recipe that can be used to install drush_make via the `drush 
 
 = PLATFORMS:
 
-The following platforms are supported by this cookbook, meaning that the 
+The following platforms are supported by this cookbook, meaning that the
 recipes run on these platforms without error.
 
 * Debian
@@ -31,6 +31,10 @@ Installs drush via PEAR package manager.
 
 Install drush via Git from source repository.
 
+== composer:
+
+Install drush via composer.
+
 == upgrade_pear:
 
 Upgrades PEAR to v1.9.1, which meets minimum required by drush via PEAR.
@@ -48,7 +52,7 @@ is already available, this command will not be run.
 
 == default:
 
-* `node['drush']['install_method']` - Indicates the desired install method, currently either `git` or `pear`.
+* `node['drush']['install_method']` - Indicates the desired install method, currently either `git`, `composer` or `pear`.
 * `node['drush']['version']` - Drush preferred state (stable, beta, devel) or version of format x.y.z when install_method is pear (eg. 5.0.0).
 When install_method is git, the format is a git reference commit/tag/branch (eg. 31d768a / 7.x-4.x / 7.x-5.0 )
 * `node['drush']['allreleases']` - URL of allreleases.xml for pear to install from preferred states.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-# 
+#
 # Author:: David King <dking@xforty.com>
 # Contributor:: Patrick Connolly <patrick@myplanetdigital.com>
 # Cookbook Name:: drush
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-# Options: pear, git
+# Options: pear, git, composer
 default['drush']['install_method'] = "pear"
 
 # Used for drush install via git and make install (PEAR stores here by default).

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,10 +8,11 @@ version          "0.10.0"
 depends          "php", ">= 0.99.0"
 recommends       "git"
 
-recipe           "drush",       "Installs Drush and dependencies."
-recipe           "drush::pear", "Installs Drush via PEAR."
-recipe           "drush::git",  "Installs Drush via Git (drupal.org repository)"
-recipe           "drush::make", "Installs Drush Make via Drush. NOT required for Drush 5."
+recipe           "drush",           "Installs Drush and dependencies."
+recipe           "drush::pear",     "Installs Drush via PEAR."
+recipe           "drush::composer", "Installs Drush via Composer."
+recipe           "drush::git",      "Installs Drush via Git (drupal.org repository)"
+recipe           "drush::make",     "Installs Drush Make via Drush. NOT required for Drush 5."
 
 %w{ debian ubuntu centos redhat }.each do |os|
   supports os

--- a/recipes/composer.rb
+++ b/recipes/composer.rb
@@ -1,0 +1,31 @@
+# Author:: Mark Sonnabaum <mark.sonnabaum@acquia.com>
+# Contributor:: Klaas Van Waesberghe <klaasvw@gmail.com>
+# Cookbook Name:: drush
+# Recipe:: composer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_recipe "composer"
+
+case node[:platform]
+when "debian", "ubuntu", "centos", "redhat"
+  execute "install_drush_composer" do
+    command "#{node['composer']['bin']} global require --no-interaction drush/drush:#{node['drush']['version']}"
+    not_if "which drush"
+  end
+
+  link "/usr/local/bin/drush" do
+    to "#{Dir.home(user)}/.composer/vendor/bin/drush"
+  end
+end


### PR DESCRIPTION
The following recipe allows users to install drush via composer.
#33 Has a similar fix but it has a different approach by switching to composer when attempting to install the master branch of drush. This pull request simply adds an additional recipe for using composer instead of git or pear.
