### PR TITLE
Add variable console table version.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,3 +34,6 @@ default['drush']['allreleases'] = "http://pear.drush.org/rest/r/drush/allrelease
 # Version number (without drupal major version) from
 # http://drupal.org/project/drush_make
 default['drush']['make']['version'] = "2.3"
+
+# The console table recipe fails if a newer version is already installed.
+default['drush']['console_table']['version'] = "1.1.6"

--- a/recipes/install_console_table.rb
+++ b/recipes/install_console_table.rb
@@ -19,5 +19,5 @@
 
 php_pear "Console_Table" do
   action :install
-  version '1.1.6'
+  version node['drush']['console_table']['version']
 end


### PR DESCRIPTION
If an attempt is made to install a lower version console table over
a higher version one, the install_console_table recipe fails. This
commit gives the user the ability to override the version of
console_table.

This commit is related to msonnabaum/chef-drush#39.
