### PR TITLE
Update berksfile format

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source "https://supermarket.chef.io"
 
 metadata
 


### PR DESCRIPTION
Pretty self explanatory. The old site format is deprecated and this is the new format.

Documentation (seems to be outdated, the URL in commit is the one suggested by the berks command)
https://github.com/berkshelf/berkshelf/wiki/2.x-to-3.0-Upgrade-Guide

Example:
https://github.com/svanzoest/apache2-cookbook/blob/master/Berksfile
