### PR TITLE
Adding support for drush 7.x

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,3 +19,10 @@ suites:
     run_list:
       - recipe[drush::default]
     attributes:
+  - name: default
+    run_list:
+      - recipe[drush::default]
+    attributes:
+      drush:
+        install_method: git
+          version: 6.x

--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,8 @@ site :opscode
 
 metadata
 
+cookbook 'composer'
+
 group :integration do
   cookbook 'apt', '~> 2.0'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,9 @@ description      "Installs drush, the Drupal Shell."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.10.0"
 depends          "php", ">= 0.99.0"
+
 recommends       "git"
+recommends       "composer"
 
 recipe           "drush",       "Installs Drush and dependencies."
 recipe           "drush::pear", "Installs Drush via PEAR."

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,18 @@
 #
 
 include_recipe "php"
+
+if node['drush']['version'].split('.').first.to_i >= 7 and node['drush']['install_method'] == 'pear'
+  Chef::Application.fatal('Drush versions above 7.0 are no longer available via PEAR. Use "github" or "git" install method to get those installed')
+end
+
 # Upgrade PEAR if current version is < 1.9.1
 include_recipe "drush::upgrade_pear" if node['drush']['install_method'] == "pear"
-include_recipe "drush::install_console_table"
+
+# Install Console_Table only if drush version is < 6.x, since
+# 6.x and above uses Composer to install requirements
+if node['drush']['version'].split('.').first.to_i < 6
+  include_recipe "drush::install_console_table"
+end
+
 include_recipe "drush::#{node['drush']['install_method']}"

--- a/recipes/git.rb
+++ b/recipes/git.rb
@@ -30,3 +30,15 @@ when "debian", "ubuntu", "centos", "redhat"
     to "#{node['drush']['install_dir']}/drush"
   end
 end
+
+# We have to run composer against the directory if we using 7.x or above
+if node['drush']['version'].split('.').first.to_i > 6
+  require_recipe "composer"
+  
+  execute 'install-drush-deps' do
+    command "composer require"
+    cwd     node['drush']['install_dir']
+    user    'root'
+    group   'root'
+  end
+end

--- a/recipes/git.rb
+++ b/recipes/git.rb
@@ -23,6 +23,7 @@ when "debian", "ubuntu", "centos", "redhat"
   git node['drush']['install_dir'] do
     repository "https://github.com/drush-ops/drush.git"
     reference node['drush']['version']
+    notifies :run, 'execute[install-drush-deps]', :immediately
     action :sync
   end
 
@@ -35,9 +36,10 @@ end
 require_recipe "composer"
 
 execute 'install-drush-deps' do
-  command "composer require"
+  command "#{node['composer']['bin']} install --no-interaction --no-ansi --quiet --no-dev"
   cwd     node['drush']['install_dir']
   user    'root'
   group   'root'
   only_if { File.exists?(node['composer']['bin']) && File.exists?(node['drush']['install_dir'] + '/composer.json') }
+  action  :nothing
 end

--- a/recipes/git.rb
+++ b/recipes/git.rb
@@ -31,14 +31,13 @@ when "debian", "ubuntu", "centos", "redhat"
   end
 end
 
-# We have to run composer against the directory if we using 7.x or above
-if node['drush']['version'].split('.').first.to_i > 6
-  require_recipe "composer"
-  
-  execute 'install-drush-deps' do
-    command "composer require"
-    cwd     node['drush']['install_dir']
-    user    'root'
-    group   'root'
-  end
+# We have to run composer against the directory if we using 6.x or above
+require_recipe "composer"
+
+execute 'install-drush-deps' do
+  command "composer require"
+  cwd     node['drush']['install_dir']
+  user    'root'
+  group   'root'
+  only_if { File.exists?(node['composer']['bin']) && File.exists?(node['drush']['install_dir'] + '/composer.json') }
 end

--- a/test/integration/git/bats/drush_installed.bats
+++ b/test/integration/git/bats/drush_installed.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+@test "drush binary is found in PATH" {
+  run which drush
+  [ "$status" -eq 0 ]
+}
+
+@test "drush status runs" {
+  run drush status
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
For Drush 7.x it is requried to run Composer against the drush directory because the project has a lot more dependencies now, installing Console_Table is not enough if you install Drush from Git.
